### PR TITLE
Added wrapExpression as an extension point

### DIFF
--- a/src/interpolationMarkup.js
+++ b/src/interpolationMarkup.js
@@ -1,3 +1,11 @@
+ko.punches.interpolationMarkup = {
+    wrapExpresssion: function(expressionText) {
+        var nodes = [];
+        nodes.push(document.createComment("ko text:" + expressionText));
+        nodes.push(document.createComment("/ko"));
+        return nodes;
+    }
+};
 // Performance comparison at http://jsperf.com/markup-interpolation-comparison
 function interpolationMarkupPreprocessor(node) {
     // only needs to work with text nodes
@@ -8,8 +16,7 @@ function interpolationMarkupPreprocessor(node) {
                 nodes.push(document.createTextNode(text));
         }
         function wrapExpr(expressionText) {
-            nodes.push(document.createComment("ko text:" + expressionText));
-            nodes.push(document.createComment("/ko"));
+            nodes = nodes.concat(ko.punches.interpolationMarkup.wrapExpresssion(expressionText));
         }
         function innerParse(text) {
             var innerMatch = text.match(/^([\s\S]*?)}}([\s\S]*)\{\{([\s\S]*)$/);
@@ -49,7 +56,6 @@ function enableInterpolationMarkup() {
 }
 
 // Export the preprocessor functions
-ko.punches.interpolationMarkup = {
-    preprocessor: interpolationMarkupPreprocessor,
-    enable: enableInterpolationMarkup
-};
+ko.punches.interpolationMarkup.preprocessor = interpolationMarkupPreprocessor;
+ko.punches.interpolationMarkup.enable = enableInterpolationMarkup;
+


### PR DESCRIPTION
Text interpolation is awesome, but it would be great to be able to do different things based on the contents - such as html interpolation. That particular case requires a modified html binding which supports virtual elements and uses a syntax that may not be universally wanted, so my commit only includes the extension point (which can be used to support a myriad of other use cases). A full example using a {{- html }} syntax for html interpolation can be found on my fiddle here: http://jsfiddle.net/daedalus28/DbEw7/
