### PR TITLE
remove hard dependency in built in preprocessors

### DIFF
--- a/src/interpolationMarkup.js
+++ b/src/interpolationMarkup.js
@@ -88,7 +88,7 @@ function wrapExpression(expressionText, node) {
 };
 
 function enableInterpolationMarkup() {
-    setNodePreprocessor(interpolationMarkupPreprocessor);
+    setNodePreprocessor(ko_punches_interpolationMarkup.preprocessor);
 }
 
 // Export the preprocessor functions
@@ -147,7 +147,7 @@ function attributeBinding(name, value, node) {
 }
 
 function enableAttributeInterpolationMarkup() {
-    setNodePreprocessor(attributeInterpolationMarkerPreprocessor);
+    setNodePreprocessor(ko_punches_attributeInterpolationMarkup.preprocessor);
 }
 
 var ko_punches_attributeInterpolationMarkup = ko_punches.attributeInterpolationMarkup = {


### PR DESCRIPTION
even when you override the preprocessors, the `enableXXXInterpolationMarkup` methods set the preprocessors to the built in implemented functions, resulting in the functions to be called every time.