### PR TITLE
Fix for Issue #46 [replaced]

### DIFF
--- a/build/fragments/pre.js
+++ b/build/fragments/pre.js
@@ -3,7 +3,7 @@
  * Enhanced binding syntaxes for Knockout 3+
  * (c) Michael Best
  * License: MIT (http://www.opensource.org/licenses/mit-license.php)
- * Version 0.5.1
+ * Version 0.5.2
  */
 (function (factory) {
     if (typeof define === 'function' && define.amd) {

--- a/src/textFilter.js
+++ b/src/textFilter.js
@@ -60,7 +60,7 @@ filters.lowercase = function(value) {
 filters['default'] = function (value, defaultValue) {
     value = ko_unwrap(value);
     if (typeof value === "function") {
-        return value;
+        value = value();
     }
     if (typeof value === "string") {
         return trim(value) === '' ? defaultValue : value;


### PR DESCRIPTION
When this commit https://github.com/mbest/knockout.punches/commit/2981643f801292722f1a80fd73316be8ac4a3151 was accepted and rewritten, the changes made missed executing the function so it's result could be evaluated against the default. This change corrects that oversight.
