### PR TITLE
Add Knockout as dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,9 @@
     "punches"
   ],
   "license": "MIT",
+  "dependencies": {
+    "knockout": ">=3.0.0"
+  },
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Consider adding Bower installation notes in README.md. The reason is because `bower.json` is not found in the master branch but only in the `gh-pages` branch.
