### PR TITLE
Enable filters for the style and css bindings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,8 @@ ko_punches.enableAll = function () {
     enableTextFilter('text');
     enableTextFilter('html');
     addDefaultNamespacedBindingPreprocessor('attr', filterPreprocessor);
+    addDefaultNamespacedBindingPreprocessor('css', filterPreprocessor);
+    addDefaultNamespacedBindingPreprocessor('style', filterPreprocessor);
 
     // Enable wrapped callbacks for click, submit, event, optionsAfterRender, and template options
     enableWrappedCallback('click');


### PR DESCRIPTION
I noticed that filters don't work for the `style` binding eg:

``` html
<div data-bind="style: {width: value | someFilter }"></div>
```

I haven't tested thoroughly but it seems that using the same configuration approach as the `attr` binding works. It is possible to achieve this without a PR using:

``` js
ko.punches.namespacedBinding.setDefaultBindingPreprocessor('style', ko.punches.textFilter.preprocessor);
```

I was wondering if there is some reason `css` and `style` bindings haven't been included so far?
